### PR TITLE
Fix invalid bash comparison causing script failure

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 set -e
 
 SRC=$(find src -name "*.cc")
@@ -8,9 +10,14 @@ if [[ $1 == "--static-analysis" ]]; then
     clang-tidy -p build --warnings-as-errors='clang-diagnostic-*,clang-analyzer-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,llvm-*,modernize-*,-modernize-use-trailing-return-type,performance-*' $SRC
 elif [[ $1 == "--formatting" ]]; then
     clang-format -n -Werror -style=file $SRC $UNIT
-    [[ $WRONG_EXT ]] && echo "Files found ending in .cpp: $WRONG_EXT" && exit 1
+    if [[ -n $WRONG_EXT ]]; then 
+        echo "Files found ending in .cpp: $WRONG_EXT"
+        exit 1
+    fi
 else
     clang-tidy -p build $SRC
     clang-format -i -style=file $SRC $UNIT
-    [[ $WRONG_EXT ]] && echo "Files found ending in .cpp: $WRONG_EXT"
+    if [[ -n $WRONG_EXT ]]; then
+        echo "Files found ending in .cpp: $WRONG_EXT"
+    fi
 fi


### PR DESCRIPTION
I'd messed up the conditions for the condition on checking file extensions.