### PR TITLE
Adds IIR filter library to CMakeLists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,9 @@
+include(FetchContent)
+FetchContent_Declare(
+    iir
+    URL https://github.com/berndporr/iir1/archive/refs/heads/master.zip
+)
+FetchContent_MakeAvailable(iir)
+
 add_executable(vocoder main.cc)
+target_link_libraries(vocoder iir::iir)


### PR DESCRIPTION
Looked into proper dependency management systems (like conan) but decided the added complexity and no longer working from HEAD was a step backwards. As such, I think we use use the FetchContent feature in CMake to source our dependencies directly from their repos.

This PR adds the IIR library to src/CMakeLists.txt

Closes #40 