### PR TITLE
CI runtime (#71)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -39,11 +39,11 @@ jobs:
     steps:      
       - name: Build executable
         working-directory: ${{github.workspace}}/build/src
-        run: make -j 2
+        run: make -j 3
 
       - name: Build unit tests
         working-directory: ${{github.workspace}}/build/unit_tests
-        run: make -j 2
+        run: make -j 3
 
 
 

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -7,6 +7,9 @@ on: [push]
 #   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 #   BUILD_TYPE: Release
 
+env:
+  path: ${{github.workspace}}/${{github.ref}}
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -16,41 +19,49 @@ jobs:
     runs-on: self-hosted    
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: ${{github.ref}}
       - name: Setup
-        run: ${{github.workspace}}/setup.sh
+        run: ${{env.path}}/setup.sh
 
   static-analysis:
     runs-on: self-hosted
     needs: checkout-and-setup
     steps:      
       - name: Analyse
-        run: ${{github.workspace}}/checks.sh --static-analysis
+        run: ${{env.path}}/checks.sh --static-analysis
 
   formatting:
     runs-on: self-hosted
     needs: checkout-and-setup
     steps:
       - name: Check Formatting
-        run: ${{github.workspace}}/checks.sh --formatting
+        run: ${{env.path}}/checks.sh --formatting
 
   build:
     runs-on: self-hosted
     needs: checkout-and-setup
     steps:      
       - name: Build executable
-        working-directory: ${{github.workspace}}/build/src
+        working-directory: ${{env.path}}/build/src
         run: make -j 3
 
       - name: Build unit tests
-        working-directory: ${{github.workspace}}/build/unit_tests
+        working-directory: ${{env.path}}/build/unit_tests
         run: make -j 3
-
-
 
   unit-test:  
     runs-on: self-hosted
     needs: build
     steps:      
       - name: Unit Tests
-        working-directory: ${{github.workspace}}/build/unit_tests
+        working-directory: ${{env.path}}/build/unit_tests
         run: ctest --timeout 1 --output-on-failure --repeat until-fail:20
+
+  tidy-up:
+    runs-on: self-hosted
+    needs: [unit-test, formatting, static-analysis]
+    steps:
+      - name: Delete everything
+        working-directory: ${{github.workspace}}
+        run: rm -r ${{env.path}}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -39,7 +39,7 @@ jobs:
     steps:      
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make 
+        run: make vocoder unit_tests -j 2
 
 
   unit-test:  
@@ -48,4 +48,4 @@ jobs:
     steps:      
       - name: Unit Tests
         working-directory: ${{github.workspace}}/build/unit_tests
-        run: ctest --timeout 1
+        run: ctest --timeout 1 --output-on-failure --repeat until-fail:20

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,10 +8,10 @@ on: [push]
 #   BUILD_TYPE: Release
 
 env:
-  path: ${{github.workspace}}/${{github.ref}}
+  path: ${{github.workspace}}/${{github.ref_name}}
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          path: ${{github.ref}}
+          path: ${{github.ref_name}}
       - name: Setup
         working-directory: ${{env.path}}
         run: ${{env.path}}/setup.sh

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           path: ${{github.ref}}
       - name: Setup
+        working-directory: ${{env.path}}
         run: ${{env.path}}/setup.sh
 
   static-analysis:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -48,4 +48,4 @@ jobs:
     steps:      
       - name: Unit Tests
         working-directory: ${{github.workspace}}/build/unit_tests
-        run: ctest --timeout 2
+        run: ctest --timeout 1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -6,6 +6,11 @@ on: [push]
 # env:
 #   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
 #   BUILD_TYPE: Release
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkout-and-setup:
     runs-on: self-hosted    
@@ -34,7 +39,7 @@ jobs:
     steps:      
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make
+        run: make 
 
 
   unit-test:  
@@ -43,6 +48,4 @@ jobs:
     steps:      
       - name: Unit Tests
         working-directory: ${{github.workspace}}/build/unit_tests
-        run: ctest
-
-
+        run: ctest --timeout 2

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -61,6 +61,7 @@ jobs:
 
   tidy-up:
     runs-on: self-hosted
+    if: always()
     needs: [unit-test, formatting, static-analysis]
     steps:
       - name: Delete everything

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -37,9 +37,14 @@ jobs:
     runs-on: self-hosted
     needs: checkout-and-setup
     steps:      
-      - name: Build
-        working-directory: ${{github.workspace}}/build
-        run: make vocoder unit_tests -j 2
+      - name: Build executable
+        working-directory: ${{github.workspace}}/build/src
+        run: make -j 2
+
+      - name: Build unit tests
+        working-directory: ${{github.workspace}}/build/unit_tests
+        run: make -j 2
+
 
 
   unit-test:  


### PR DESCRIPTION
Half CI run time while increasing robustness by requiring tests to run multiple times without failing.

Closes #71 
Closes #56 by making CI jobs independent of jobs for other branches