### PR TITLE
Move timeout to class constructors

### DIFF
--- a/include/filter/filter.hh
+++ b/include/filter/filter.hh
@@ -11,7 +11,7 @@
 class BPFilter {
   public:
     BPFilter(int order, double sampling_rate, double centre_freq_, double freq_range_, Pipe<Audio> &input_,
-             Pipe<Audio> &output_);
+             Pipe<Audio> &output_, std::chrono::milliseconds timeout_);
 
     ~BPFilter();
 
@@ -34,7 +34,7 @@ class BPFilter {
 
     std::thread filter_thread;
     bool thread_alive{false};
-    const std::chrono::milliseconds timeout{1};
+    const std::chrono::milliseconds timeout;
 };
 
 #endif

--- a/include/mixer/mixer.hh
+++ b/include/mixer/mixer.hh
@@ -23,11 +23,11 @@ template <std::size_t num_banks> class Mixer {
 
     bool run_thread{};
     std::thread thread;
-    const std::chrono::milliseconds timeout{1};
+    const std::chrono::milliseconds timeout;
 
   public:
-    Mixer(std::array<Pipe<Audio>, num_banks> &input_pipes, Pipe<Audio> &output_pipe)
-        : input_pipes(input_pipes), output_pipe(output_pipe) {
+    Mixer(std::array<Pipe<Audio>, num_banks> &input_pipes_, Pipe<Audio> &output_pipe_, std::chrono::milliseconds timeout_)
+        : input_pipes(input_pipes_), output_pipe(output_pipe_), timeout(timeout_) {
     }
 
     // explicitly disable copy and move constructors since that will mess

--- a/include/rms/rms.hh
+++ b/include/rms/rms.hh
@@ -23,12 +23,12 @@ template <std::size_t num_samples> class RMS {
     std::array<uint32_t, num_samples> squared_sample_buffer = {0};
     int sample_buffer_index = 0;
 
-    const std::chrono::milliseconds timeout{1};
+    const std::chrono::milliseconds timeout;
     bool thread_alive{false};
     std::thread thread;
 
   public:
-    RMS(Pipe<Audio> &input_pipe, Pipe<double> &output_pipe) : input_pipe(input_pipe), output_pipe(output_pipe) {
+    RMS(Pipe<Audio> &input_pipe, Pipe<double> &output_pipe, std::chrono::milliseconds timeout) : input_pipe(input_pipe), output_pipe(output_pipe), timeout(timeout) {
     }
 
     void insert(Audio packet) {

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -1,8 +1,8 @@
 #include "../include/filter/filter.hh"
 
 BPFilter::BPFilter(int order, double sampling_rate, double centre_freq_, double freq_range_, Pipe<Audio> &input_,
-                   Pipe<Audio> &output_)
-    : centre_freq(centre_freq_), freq_range(freq_range_), input(input_), output(output_) {
+                   Pipe<Audio> &output_, std::chrono::milliseconds timeout_)
+    : centre_freq(centre_freq_), freq_range(freq_range_), input(input_), output(output_), timeout(timeout_) {
 
     f.setup(order, sampling_rate, centre_freq, freq_range);
 }

--- a/unit_tests/filter_test.cc
+++ b/unit_tests/filter_test.cc
@@ -20,7 +20,7 @@ TEST(FilterTest, EmptyReturn) {
     Pipe<Audio> in_pipe;
     Pipe<Audio> out_pipe;
 
-    BPFilter f(2, sampling_rate, centre, width, in_pipe, out_pipe);
+    BPFilter f(2, sampling_rate, centre, width, in_pipe, out_pipe, std::chrono::milliseconds(100));
 
     // High freq sin
     const unsigned int freq = 75;
@@ -51,7 +51,7 @@ TEST(FilterTest, HighFrequencyResponse) {
     Pipe<Audio> in;
     Pipe<Audio> out;
 
-    BPFilter f(2, sampling_rate, centre, width, in, out);
+    BPFilter f(2, sampling_rate, centre, width, in, out, std::chrono::milliseconds(100));
 
     // High freq sin
     const unsigned int high_freq = 200;
@@ -78,7 +78,7 @@ TEST(FilterTest, PassFrequencyResponse) {
     Pipe<Audio> in;
     Pipe<Audio> out;
 
-    BPFilter f(2, sampling_rate, centre, width, in, out);
+    BPFilter f(2, sampling_rate, centre, width, in, out, std::chrono::milliseconds(100));
 
     // High freq sin
     const unsigned int pass_freq = 75;
@@ -109,7 +109,7 @@ TEST(FilterTest, LowFrequencyResponse) {
     Pipe<Audio> in;
     Pipe<Audio> out;
 
-    BPFilter f(2, sampling_rate, centre, width, in, out);
+    BPFilter f(2, sampling_rate, centre, width, in, out, std::chrono::milliseconds(100));
 
     // High freq sin
     const unsigned int low_freq = 30;
@@ -137,7 +137,7 @@ TEST(FilterTest, RunTimeTest) {
     Pipe<Audio> in;
     Pipe<Audio> out;
 
-    BPFilter f(2, sampling_rate, centre, width, in, out);
+    BPFilter f(2, sampling_rate, centre, width, in, out, std::chrono::milliseconds(100));
 
     // High freq sin
     const unsigned int freq = 30;
@@ -165,7 +165,7 @@ TEST(FilterTest, ThreadAndMessaging) {
     Pipe<Audio> in_pipe;
     Pipe<Audio> out_pipe;
 
-    BPFilter f(2, sampling_rate, centre, width, in_pipe, out_pipe);
+    BPFilter f(2, sampling_rate, centre, width, in_pipe, out_pipe, std::chrono::milliseconds(100));
 
     f.run();
 

--- a/unit_tests/mixer_tests.cc
+++ b/unit_tests/mixer_tests.cc
@@ -24,7 +24,7 @@ TEST(MixerTests, Timeout) {
     Pipe<Audio> output{};
     std::array<Pipe<Audio>, 2> inputs{};
     {
-        mixer::Mixer<2> mixer(inputs, output);
+        mixer::Mixer<2> mixer(inputs, output, std::chrono::milliseconds(100));
 
         // start mixer
         mixer.run();
@@ -39,7 +39,7 @@ TEST(MixerTests, Integration) {
     // set up mixer with 2 inputs
     Pipe<Audio> output{};
     std::array<Pipe<Audio>, 2> inputs{};
-    mixer::Mixer<2> mixer(inputs, output);
+    mixer::Mixer<2> mixer(inputs, output, std::chrono::milliseconds(100));
 
     // start mixer
     mixer.run();

--- a/unit_tests/rms_tests.cc
+++ b/unit_tests/rms_tests.cc
@@ -18,7 +18,7 @@
 TEST(RMSTests, buffer) {
     Pipe<Audio> input{};
     Pipe<double> output{};
-    rms::RMS<4> rms(input, output);
+    rms::RMS<4> rms(input, output, std::chrono::milliseconds(100));
     Audio audio{0};
 
     // check that rms is 0 at the beginning
@@ -56,7 +56,7 @@ TEST(RMSTests, buffer) {
 TEST(RMSTests, Integration) {
     Pipe<Audio> input{};
     Pipe<double> output{};
-    rms::RMS<4> rms(input, output);
+    rms::RMS<4> rms(input, output, std::chrono::milliseconds(100));
 
     rms.run();
 


### PR DESCRIPTION
Closes #86 

I don't think we want to have a project wide constant, since there is no good software engineering way to do that. defines are generally banned and other solutions seem hacky.