### PR TITLE
Class destructors

### DIFF
--- a/include/amp.hh
+++ b/include/amp.hh
@@ -18,11 +18,11 @@ class Amplifier {
      * @param timeout_ Time in milliseconds the thread will wait before exiting if no data provided.
      */
     Amplifier(Pipe<Audio> &input_, Pipe<double> &scaling_, Pipe<Audio> &output_, std::chrono::milliseconds timeout_);
-    ~Amplifier();
-    Amplifier(const Amplifier &) = delete;
-    Amplifier &operator=(const Amplifier &) = delete;
-    Amplifier(Amplifier &&) = delete;
-    Amplifier &operator=(Amplifier &&) = delete;
+    
+    /**
+     *  Requests for the calculation thread to join.
+     */
+    void stop();
 
     /**
      * Run function. Opens a thread and continuously scales input audio by scaling, outputting the scaled audio.

--- a/include/amp.hh
+++ b/include/amp.hh
@@ -18,7 +18,7 @@ class Amplifier {
      * @param timeout_ Time in milliseconds the thread will wait before exiting if no data provided.
      */
     Amplifier(Pipe<Audio> &input_, Pipe<double> &scaling_, Pipe<Audio> &output_, std::chrono::milliseconds timeout_);
-    
+
     /**
      *  Requests for the calculation thread to join.
      */

--- a/include/filter.hh
+++ b/include/filter.hh
@@ -27,30 +27,10 @@ class BPFilter {
              Pipe<Audio> &output_, std::chrono::milliseconds timeout_);
 
     /**
-     * Bandpass deconstructor.
+     * Stop thread
+     * Requests the thread to join.
      */
-    ~BPFilter();
-
-    /**
-     * Overridden move constructor
-     * Overridden as the destructor has been modified
-     */
-    BPFilter(const BPFilter &) = delete;
-    /**
-     * Overridden move constructor
-     * Overridden as the destructor has been modified
-     */
-    BPFilter &operator=(const BPFilter &) = delete;
-    /**
-     * Overridden move constructor
-     * Overridden as the destructor has been modified
-     */
-    BPFilter(BPFilter &&) = delete;
-    /**
-     * Overridden move constructor
-     * Overridden as the destructor has been modified
-     */
-    BPFilter &operator=(BPFilter &&) = delete;
+    void stop();
 
     /**
      * Run thread function

--- a/include/mixer.hh
+++ b/include/mixer.hh
@@ -45,26 +45,6 @@ template <std::size_t num_banks> class Mixer {
         : input_pipes(input_pipes_), output_pipe(output_pipe_), timeout(timeout_) {
     }
 
-    // explicitly disable copy and move constructors since that will mess
-    // with threading logic. if these are needed it can be reviewed later
-    /**
-     * Explicitly delete the copy constructor.
-     */
-    Mixer(const Mixer &) = delete;
-    /**
-     * Explicitly delete the copy assignment constructor.
-     */
-    Mixer &operator=(const Mixer &) = delete;
-    /**
-     * Explicitly delete move assignment constructor.
-     *
-     */
-    Mixer(Mixer &&) = delete;
-    /**
-     * Explicitly delete move assignment constructor.
-     */
-    Mixer &operator=(Mixer &&) = delete;
-
     /**
      * Sums the samples at matching points on each sub array and combines it in to a single array of samples
      *
@@ -117,7 +97,7 @@ template <std::size_t num_banks> class Mixer {
     /**
      * Join the mixer thread when the destructor is called
      */
-    ~Mixer() {
+    void stop() {
         thread.join();
     }
 };

--- a/src/amp.cc
+++ b/src/amp.cc
@@ -16,7 +16,7 @@ Amplifier::Amplifier(Pipe<Audio> &input_, Pipe<double> &scaling_, Pipe<Audio> &o
     : input(input_), scaling(scaling_), output(output_), timeout(timeout_) {
 }
 
-Amplifier::~Amplifier() {
+void Amplifier::stop() {
     if (thread_alive) {
         amplifier_thread.join();
     }

--- a/src/filter.cc
+++ b/src/filter.cc
@@ -7,7 +7,8 @@ BPFilter::BPFilter(int order, double sampling_rate, double centre_freq_, double 
 
     f.setup(order, sampling_rate, centre_freq, freq_range);
 }
-BPFilter::~BPFilter() {
+
+void BPFilter::stop() {
     if (thread_alive) {
         filter_thread.join();
     }

--- a/unit_tests/amp_test.cc
+++ b/unit_tests/amp_test.cc
@@ -121,5 +121,6 @@ TEST(AmpTest, ThreadAndMessaging) {
     std::cerr << "Scale stopped" << std::endl;
     output_thread.join();
     std::cerr << "Output stopped" << std::endl;
+    a.stop();
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)

--- a/unit_tests/amp_test.cc
+++ b/unit_tests/amp_test.cc
@@ -42,6 +42,22 @@ TEST(AmpTest, Amplification) {
 
 // TEST macro violates guidelines
 // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-avoid-non-const-global-variables)
+TEST(AmpTest, Vectorable) {
+    // This test will fail to compile if the class has no copy/move construtors
+    const int num_amps = 6;
+    std::vector<Amplifier> amp_vector;
+    Pipe<Audio> in_pipe;
+    Pipe<double> scale_pipe;
+    Pipe<Audio> out_pipe;
+
+    amp_vector.reserve(num_amps);
+    for (int i = 0; i < num_amps; i++) {
+        amp_vector.emplace_back(in_pipe, scale_pipe, out_pipe, std::chrono::milliseconds(100));
+    }
+}
+
+// TEST macro violates guidelines
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-avoid-non-const-global-variables)
 TEST(AmpTest, ThreadAndMessaging) {
     Pipe<Audio> in_pipe;
     Pipe<double> scale_pipe;

--- a/unit_tests/filter_test.cc
+++ b/unit_tests/filter_test.cc
@@ -262,6 +262,7 @@ TEST(FilterTest, ThreadAndMessaging) {
     std::cerr << "Input stopped" << std::endl;
     output_thread.join();
     std::cerr << "Output stopped" << std::endl;
+    f.stop();
 }
 
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)

--- a/unit_tests/filter_test.cc
+++ b/unit_tests/filter_test.cc
@@ -42,6 +42,26 @@ TEST(FilterTest, EmptyReturn) {
     EXPECT_TRUE(flag) << "Filter returned all zeros";
 }
 
+// Test that filters can be initialised in an array
+// TEST macro violates guidelines
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-avoid-non-const-global-variables)
+TEST(FilterTest, Vectorable) {
+    int num_filters = 8;
+    std::vector<BPFilter> filter_array;
+    filter_array.reserve(num_filters);
+
+    const unsigned int centre = 75;
+    const unsigned int width = 20;
+    Pipe<Audio> in_pipe;
+    Pipe<Audio> out_pipe;
+
+    for (int i = 0; i < num_filters; i++) {
+        filter_array.emplace_back(2, sampling_rate, centre, width, in_pipe, out_pipe, std::chrono::milliseconds(100));
+    }
+
+    ASSERT_TRUE(filter_array.size() == 8);
+}
+
 // Test filter function at a frequency above the pass band
 // TEST macro violates guidelines
 // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-avoid-non-const-global-variables)

--- a/unit_tests/mixer_tests.cc
+++ b/unit_tests/mixer_tests.cc
@@ -1,5 +1,6 @@
 #include "../include/mixer.hh"
 #include <array>
+#include <chrono>
 #include <condition_variable>
 #include <gtest/gtest.h>
 #include <mutex>
@@ -31,6 +32,21 @@ TEST(MixerTests, Timeout) {
     } // mixer goes out of scope so destructor is called
 
     ASSERT_TRUE(true); // when run with a timeout this will fail if it doesn't reach this point
+}
+
+// TEST macro violates guidelines
+// NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-avoid-non-const-global-variables)
+TEST(MixerTests, Vectorable) {
+    // This test will fail to compile if the class has no copy/move construtors
+    const int num_mixers = 3;
+    std::vector<mixer::Mixer<4>> mixer_vector;
+    Pipe<Audio> output;
+    std::array<Pipe<Audio>, num_mixers> inputs{};
+
+    mixer_vector.reserve(num_mixers);
+    for (int i = 0; i < num_mixers; i++) {
+        mixer_vector.emplace_back(inputs, output, std::chrono::milliseconds(100));
+    }
 }
 
 // TEST macro violates guidelines

--- a/unit_tests/mixer_tests.cc
+++ b/unit_tests/mixer_tests.cc
@@ -41,7 +41,7 @@ TEST(MixerTests, Vectorable) {
     const int num_mixers = 3;
     std::vector<mixer::Mixer<4>> mixer_vector;
     Pipe<Audio> output;
-    std::array<Pipe<Audio>, num_mixers> inputs{};
+    std::array<Pipe<Audio>, 4> inputs{};
 
     mixer_vector.reserve(num_mixers);
     for (int i = 0; i < num_mixers; i++) {
@@ -94,6 +94,7 @@ TEST(MixerTests, Integration) {
     input_thread1.join();
     input_thread2.join();
     output_thread.join();
+    mixer.stop();
 }
 
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)

--- a/unit_tests/mixer_tests.cc
+++ b/unit_tests/mixer_tests.cc
@@ -24,12 +24,12 @@ TEST(MixerTests, Timeout) {
     // set up mixer with 2 inputs
     Pipe<Audio> output{};
     std::array<Pipe<Audio>, 2> inputs{};
-    {
-        mixer::Mixer<2> mixer(inputs, output, std::chrono::milliseconds(100));
 
-        // start mixer
-        mixer.run();
-    } // mixer goes out of scope so destructor is called
+    mixer::Mixer<2> mixer(inputs, output, std::chrono::milliseconds(100));
+
+    // start mixer
+    mixer.run();
+    mixer.stop();
 
     ASSERT_TRUE(true); // when run with a timeout this will fail if it doesn't reach this point
 }


### PR DESCRIPTION
Closes #98 by adding unit tests to ensure classes can be constructed in arrays and allowing the implicit copy constructors to work.